### PR TITLE
fix(GIST-69): added /gists/raw/:id route

### DIFF
--- a/gists/controller.go
+++ b/gists/controller.go
@@ -81,6 +81,19 @@ func (g *GistControllerImpl) FindByID() fiber.Handler {
 	}
 }
 
+func (g *GistControllerImpl) RawFindByID() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		owner_id := c.Locals("pub").(string)
+
+		gist, err := GistService.FindByID(c.Params("id"), owner_id)
+		if err != nil {
+			return c.Status(404).SendString(err.Error())
+		}
+
+		return c.Status(200).SendString(gist.Content)
+	}
+}
+
 func (g *GistControllerImpl) UpdateContent() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		g := new(GistSaveValidator)

--- a/gists/router.go
+++ b/gists/router.go
@@ -19,5 +19,6 @@ func (r *GistRouter) SubscribeRoutes(app *fiber.Router) {
 	gists_router.Patch("/:id/description", r.Controller.UpdateDescription())
 	gists_router.Get("/", r.Controller.FindAll())
 	gists_router.Get("/:id", r.Controller.FindByID())
+	gists_router.Get("/raw/:id", r.Controller.RawFindByID())
 	gists_router.Delete("/:id", r.Controller.Delete())
 }


### PR DESCRIPTION
- **feat(GIST-69): added raw parameter to url to get raw gists**
- **fix(GIST-69): added /gists/raw/:id to fetch raw gists**

Needed to add such routes since traefik encode query params when rewriting the request. So we can't use query params for `raw.gists.app`
